### PR TITLE
feat: Clear scores on model change & add user data export

### DIFF
--- a/Chrome/src/popup.html
+++ b/Chrome/src/popup.html
@@ -135,6 +135,7 @@
 
         <div class="section">
             <div class="actions">
+                <button id="exportUserData" class="btn btn-info">Export User Data</button>
                 <button id="clearData" class="btn btn-secondary">Clear All Data</button>
                 <button id="analyzeNow" class="btn btn-primary">Analyze Current Page</button>
             </div>

--- a/Firefox/src/popup.html
+++ b/Firefox/src/popup.html
@@ -135,6 +135,7 @@
 
         <div class="section">
             <div class="actions">
+                <button id="exportUserData" class="btn btn-info">Export User Data</button>
                 <button id="clearData" class="btn btn-secondary">Clear All Data</button>
                 <button id="analyzeNow" class="btn btn-primary">Analyze Current Page</button>
             </div>


### PR DESCRIPTION
This commit introduces two main features:

1.  Clear local scores on classifier model change: When you select a new classifier model from the popup, all locally stored user scores (`reddit-user-scores` in local storage) are now automatically deleted. The content script is also notified to refresh its data, ensuring that scores from different models are not mixed.

2.  Add user data export button: A new "Export User Data" button has been added to the extension popup (for both Chrome and Firefox). Clicking this button allows you to download a CSV file (`reddit_user_data_export.csv`) containing data for all known users.

    The CSV includes the following columns for each user:
    - Username
    - PostsScanned (total number of comments analyzed for the user)
    - AIPosts (number of comments classified as AI-generated)
    - HumanPosts (number of comments classified as human-written)
    - ModelUsed (the classifier model currently selected in the extension)

These changes enhance data integrity by preventing model score mismatches and provide you with a way to access your collected data.